### PR TITLE
core/values: Updated secrets references for dex & oauth2-proxy

### DIFF
--- a/core/layers/base/values/core/releases/releases-secrets.yaml
+++ b/core/layers/base/values/core/releases/releases-secrets.yaml
@@ -330,7 +330,7 @@ releases:
         extraAnnotations: {}
         extraLabels: {}
         enabled: true
-        replicateFrom: dex/default-oauth2-client
+        replicateFrom: dex/dex-dynamic-secrets-default-oauth2-client
         secretRef:
           key: DEFAULT_STATIC_CLIENT_ID,DEFAULT_STATIC_CLIENT_SECRET
           name: default-oauth2-client

--- a/core/values/dex.yaml.gotmpl
+++ b/core/values/dex.yaml.gotmpl
@@ -70,12 +70,12 @@ envVars:
   - name: DEFAULT_STATIC_CLIENT_ID
     valueFrom:
       secretKeyRef:
-        name: {{ (index .Values.releases .Release.Name "dynamicSecrets" "default-oauth2-client" "secretRef" "name" ) }}
+        name: {{ printf "%s-dynamic-secrets-%s" .Release.Name (index .Values.releases .Release.Name "dynamicSecrets" "default-oauth2-client" "secretRef" "name" ) }}
         key: DEFAULT_STATIC_CLIENT_ID
   - name: DEFAULT_STATIC_CLIENT_SECRET
     valueFrom:
       secretKeyRef:
-        name: {{ (index .Values.releases .Release.Name "dynamicSecrets" "default-oauth2-client" "secretRef" "name" ) }}
+        name: {{ printf "%s-dynamic-secrets-%s" .Release.Name (index .Values.releases .Release.Name "dynamicSecrets" "default-oauth2-client" "secretRef" "name" ) }}
         key: DEFAULT_STATIC_CLIENT_SECRET
   - name: DEFAULT_OIDC_CONNECTORS_ID
     valueFrom:

--- a/core/values/oauth2-proxy.yaml.gotmpl
+++ b/core/values/oauth2-proxy.yaml.gotmpl
@@ -81,8 +81,10 @@ extraEnv:
   - name: OAUTH2_PROXY_COOKIE_SECRET
     valueFrom:
       secretKeyRef:
-        name: oauth2-cookie-secret
+        name: {{ printf "%s-dynamic-secrets-%s" .Release.Name (index .Values.releases .Release.Name "dynamicSecrets" "oauth2-cookie-secret" "secretRef" "name" ) }}
         key: OAUTH2_PROXY_COOKIE_SECRET
+
+
 
 metrics:
   enabled: {{ index .Values.releases .Release.Name "config" "metrics" "enabled" }}


### PR DESCRIPTION
This fixes the secrets used by both releases, as several references changed with refactoring on dynamic-secrets