### PR TITLE
Reworked chartmuseum integration in kube-core

### DIFF
--- a/core/layers/base/values/core/releases/releases-cloud.yaml
+++ b/core/layers/base/values/core/releases/releases-cloud.yaml
@@ -11,6 +11,11 @@ releases:
       roles:
       - roles/compute.admin
       - roles/container.admin
+  chartmuseum:
+    cloud:
+      enabled: true
+      bucket:
+        enabled: true
   cluster-issuers:
     cloud:
       enabled: true

--- a/core/layers/base/values/core/releases/releases-config.yaml
+++ b/core/layers/base/values/core/releases/releases-config.yaml
@@ -117,28 +117,41 @@ releases:
         # nginx.ingress.kubernetes.io/rewrite-target: /$1
         labels: {}
         subdomain: prometheus-pushgateway
+  
   chartmuseum:
     config:
-      env:
-        open:
-          ALLOW_OVERWRITE: true
-          AUTH_ANONYMOUS_GET: true
-          DISABLE_API: false
-          DISABLE_METRICS: false
-          DISABLE_STATEFILES: true
-      ingress:
-        annotations:
-          cert-manager.io/cluster-issuer: letsencrypt-prod
-          nginx.ingress.kubernetes.io/server-snippet: |
-            location ~ ^/(metrics) {
-              deny all;
-              return 403;
-            }
-        labels:
-          ingress.neo9.io/access-filtered: "false"
-        subdomain: charts
-      persistence:
+      museum:
+        cacheInterval: 1m
+        allowOverwrite: true
+        authAnonymousGet: true
+        disableStatefiles: true
+        disableApi: false
+        adminUser: devops
+      storage:
+        cloudOrLocal: cloud
+        bucketName: "chartmuseum"
+        bucketPrefix: ""
+      metrics:
         enabled: true
+        serviceMonitor:
+          enabled: false
+      ingress:
+        enabled: true
+        annotations: {}
+        labels: {}
+        subdomain: charts
+    customExtensions:
+      enabled: true
+      resources:
+        prometheus-servicemonitor:
+          default:
+            enabled: true
+            targetName: chartmuseum
+            endpoints:
+            - port: http
+              interval: 2s
+              path: /metrics
+
   container-registry-cleaner:
     config:
       concurrencyPolicy: Forbid

--- a/core/layers/base/values/core/releases/releases-dynamic-secrets.yaml
+++ b/core/layers/base/values/core/releases/releases-dynamic-secrets.yaml
@@ -1,4 +1,16 @@
 releases:
+
+  chartmuseum:
+    dynamicSecrets:
+      basic-admin-password:
+        enabled: true
+        description: Default basic password for admin user of chartmuseum
+        config:
+          length: 32
+        secretRef:
+          key: BASIC_AUTH_PASS
+          name: basic-admin-password
+
   dex:
     dynamicSecrets:
       default-oauth2-client:

--- a/core/layers/base/values/core/releases/releases-options.yaml
+++ b/core/layers/base/values/core/releases/releases-options.yaml
@@ -13,6 +13,10 @@ releases:
       patchIngresses: true
       upgradeIngress: true
       upgradeIngressPortIsHttp: true
+  chartmuseum:
+    options:
+      injectClusterLoggingLabel: true
+      injectReloaderAnnotations: true
   dex:
     options:
       injectReloaderAnnotations: true

--- a/core/layers/base/values/core/releases/releases-secrets.yaml
+++ b/core/layers/base/values/core/releases/releases-secrets.yaml
@@ -1,4 +1,17 @@
 releases:
+  chartmuseum:
+    secrets:
+      credentials:
+        description: Credentials to authenticate to your Cloud Provider.
+        crossplaneGenerated: true
+        extraAnnotations: {}
+        extraLabels: {}
+        enabled: true
+        replicateFrom: secrets/chartmuseum
+        secretRef:
+          key: privateKey
+          name: chartmuseum
+        type: "Opaque"
   cluster-issuers:
     secrets:
       credentials:

--- a/core/layers/base/values/core/releases/releases-values.yaml
+++ b/core/layers/base/values/core/releases/releases-values.yaml
@@ -1,13 +1,4 @@
 releases:
-  chartmuseum:
-    values:
-      extraArgs:
-        - --cache-interval=1m
-      gcp:
-        secret:
-          enabled: false
-          key: chartmuseum-sa.json
-          name: chartmuseum-sa
   cluster-logging:
     values:
       installCRDs: false

--- a/core/values/chartmuseum.yaml.gotmpl
+++ b/core/values/chartmuseum.yaml.gotmpl
@@ -1,52 +1,107 @@
-extraArgs: []
+{{/* Release Values Templates Header - START */}}
+{{ $values := (coalesce (. | getOrNil "values") (. | getOrNil "Values")) }}
+{{ $release := (index $values.releases .Release.Name) }}
+{{ $releaseName := .Release.Name }}
+{{ $releaseNamespace := .Release.Namespace }}
+{{ $releaseType := $release.type }}
+
+{{ $_ := set $release "name" $releaseName }}
+{{ $_ := set $release "namespace" $releaseNamespace }}
+{{ (tpl (readFile "../templates/releases/standard/variables/release-variables-config.yaml.gotmpl") (dict "item" $release "values" $values)) }}
+{{ (tpl (readFile "../templates/releases/standard/variables/release-variables-cloud.yaml.gotmpl") (dict "item" $release "values" $values)) }}
+{{/* Release Values Templates Header - END */}}
+
+{{ $bucketName := "chartmuseum" }}
+{{ if $release.metadata.config.cloudEnabled }}
+{{ $bucketName = $release.metadata.namingConfig.templated.releaseBucketName }}
+{{ else }}
+{{ $bucketName = ($values | get "cluster.config.storage.bucketName" (printf "%s-chartmuseum" $values.cluster.config.name)) }}
+{{ end }}
+
 replicaCount: 1
+
+resources: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
 strategy:
   type: RollingUpdate
   rollingUpdate:
+    maxSurge: 1
     maxUnavailable: 0
-image:
-  repository: ghcr.io/helm/chartmuseum
-  tag: v0.13.1
-  pullPolicy: IfNotPresent
-secret:
-  labels: {}
-env:
-  {{- if (index .Values.releases .Release.Name "config" "env") }}
-    {{ toYaml (index .Values.releases .Release.Name "config" "env") | nindent 2 }}
-  {{- end }}
-
-probes:
-  readiness:
-    periodSeconds: 2
-    initialDelaySeconds: 20
-
-persistence:
-  # Default operation mode should be with bucket/object storage, persistence only usefull for test with local storage
-  enabled: {{ (index .Values.releases .Release.Name "config" "persistence" "enabled") }}
-  accessMode: ReadWriteOnce
-  size: 8Gi
-  labels: {}
-    # name: value
-  path: /storage
 
 ingress:
   enabled: true
+  ingressClassName: {{ $values.cluster.common.defaultIngressClass }}
   annotations:
+    nginx.ingress.kubernetes.io/server-snippet: |
+      location ~* "^/metrics" {
+        deny all;
+        return 403;
+      }
     {{ if .Values.cluster.common.defaultIngressAnnotations }}
       {{ toYaml .Values.cluster.common.defaultIngressAnnotations | nindent 4 }}
     {{- end }}
-    {{- if (index .Values.releases .Release.Name "config" "ingress" "annotations") }}
-      {{ toYaml (index .Values.releases .Release.Name "config" "ingress" "annotations") | nindent 4 }}
+    {{- if (index $release "config" "ingress" "annotations") }}
+      {{ toYaml (index $release "config" "ingress" "annotations") | nindent 4 }}
     {{- end }}
   labels:
     {{ if .Values.cluster.common.defaultIngressLabels }}
       {{ toYaml .Values.cluster.common.defaultIngressLabels | nindent 4 }}
     {{- end }}
-    {{- if (index .Values.releases .Release.Name "config" "ingress" "labels") }}
-      {{ toYaml (index .Values.releases .Release.Name "config" "ingress" "labels") | nindent 4 }}
+    {{- if (index $release "config" "ingress" "labels") }}
+      {{ toYaml (index $release "config" "ingress" "labels") | nindent 4 }}
     {{- end }}
   hosts:
-    - name: {{ (index .Values.releases .Release.Name "config" "ingress" "subdomain") }}.{{ .Values.cluster.config.domain }}
+    - name: {{ (index $release "config" "ingress" "subdomain") }}.{{ .Values.cluster.config.domain }}
       path: /
       tls: true
-      tlsSecret: {{ (index .Values.releases .Release.Name "config" "ingress" "subdomain") | replace "." "-"}}-tls
+      tlsSecret: {{ (index $release "config" "ingress" "subdomain") | replace "." "-"}}-tls
+
+serviceMonitor:
+  enabled: false
+{{/* As the chart use .Capabilities.APIVersions.Has which have issue, we create the serviceMonitor separately
+  enabled: {{ or (index $release "config" "metrics" "serviceMonitor" "enabled") $values.core.packages.monitoring.enabled ($values.releases.kps.enabled) }}
+*/}}
+
+# https://chartmuseum.com/docs/#all-cli-options
+env:
+  open:
+    ENABLE_METRICS: {{ or (index $release "config" "metrics" "enabled") ($values.releases.kps.enabled) }}
+    CACHE_INTERVAL: {{ index $release "config" "museum" "cacheInterval" }}
+    ALLOW_OVERWRITE: {{ index $release "config" "museum" "allowOverwrite" }}
+    AUTH_ANONYMOUS_GET: {{ index $release "config" "museum" "authAnonymousGet" }}
+    DISABLE_STATEFILES: {{ index $release "config" "museum" "disableStatefiles" }}
+    DISABLE_API: {{ index $release "config" "museum" "disableApi" }}
+    BASIC_AUTH_USER: {{ index $release "config" "museum" "adminUser" }}
+  {{ if eq (index $release "config" "storage" "cloudOrLocal") "local" }}
+    STORAGE: local
+  {{ else if eq (index $release "config" "storage" "cloudOrLocal") "cloud" }}
+    {{ if eq $values.cloud.provider "gcp" }}
+    STORAGE: google
+    STORAGE_GOOGLE_BUCKET: {{ $bucketName }}
+    STORAGE_GOOGLE_PREFIX: {{ index $release "config" "storage" "bucketPrefix" }}
+    {{ end }}
+  {{ end }}
+  existingSecret: chartmuseum-dynamic-secrets-basic-admin-password
+  existingSecretMappings:
+    BASIC_AUTH_PASS: BASIC_AUTH_PASS
+
+{{ if eq (index $release "config" "storage" "cloudOrLocal") "cloud" }}
+{{ if eq $values.cloud.provider "gcp" }}
+gcp:
+  secret:
+    enabled: true
+    key: privateKey
+    name: chartmuseum
+{{ end }}
+{{ end }}
+
+persistence:
+  # Default operation mode should be with bucket/object storage, persistence only usefull for test with local storage
+  {{ if eq (index $release "config" "storage" "cloudOrLocal") "local" }}
+  enabled: true
+  {{ else }}
+  enabled: false
+  {{ end }}

--- a/core/values/kps.yaml.gotmpl
+++ b/core/values/kps.yaml.gotmpl
@@ -317,6 +317,16 @@ kps:
             orgId: 1
             type: file
           {{- end }}
+          {{- if index $values.releases "chartmuseum" "enabled" }}
+          - disableDeletion: true
+            editable: false
+            folder: Chartmuseum
+            name: chartmuseum
+            options:
+              path: /var/lib/grafana/dashboards/chartmuseum
+            orgId: 1
+            type: file
+          {{- end }}
           {{- if ( $values | get (printf "releases.%s.config.grafana.dashboardProviders" .Release.Name ) false) }}
           {{ toYaml (index $release "config" "grafana" "dashboardProviders") | nindent 10 }}
           {{- end }}
@@ -430,6 +440,12 @@ kps:
         pyrra-list:
           datasource: Thanos
           url: https://raw.githubusercontent.com/pyrra-dev/pyrra/main/examples/grafana/list.json
+      {{- end }}
+      {{- if index $values.releases "chartmuseum" "enabled" }}
+      chartmuseum:
+        chartmuseum-dashboard:
+          datasource: Thanos
+          url: https://raw.githubusercontent.com/neo9/grafana-dashboards/master/chartmuseum/chartmuseum.json
       {{- end }}
       kube-core:
       {{- if index $values.releases "kyverno" "enabled" }}

--- a/releases/dist/releases/charts/chartmuseum/Chart.yaml
+++ b/releases/dist/releases/charts/chartmuseum/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.13.1
+appVersion: 0.15.0
 description: Host your own Helm Chart Repository
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/charts/main/logo.jpg
@@ -15,4 +15,4 @@ sources:
 - https://github.com/chartmuseum/charts/tree/main/src/chartmuseum
 - https://github.com/chartmuseum
 - https://github.com/helm/chartmuseum
-version: 3.4.0
+version: 3.9.3

--- a/releases/dist/releases/charts/chartmuseum/templates/_helpers.tpl
+++ b/releases/dist/releases/charts/chartmuseum/templates/_helpers.tpl
@@ -45,6 +45,9 @@ helm.sh/chart: {{ include "chartmuseum.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/releases/dist/releases/charts/chartmuseum/templates/deployment.yaml
+++ b/releases/dist/releases/charts/chartmuseum/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
       {{- end }}
       labels:
         {{- include "chartmuseum.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
@@ -120,11 +123,13 @@ spec:
           httpGet:
             path: {{ .Values.env.open.CONTEXT_PATH }}/health
             port: http
+{{ toYaml .Values.probes.livenessHttpGetConfig | indent 12 }}
 {{ toYaml .Values.probes.liveness | indent 10 }}
         readinessProbe:
           httpGet:
             path: {{ .Values.env.open.CONTEXT_PATH }}/health
             port: http
+{{ toYaml .Values.probes.readinessHttpGetConfig | indent 12 }}
 {{ toYaml .Values.probes.readiness | indent 10 }}
         volumeMounts:
 {{- if .Values.deployment.extraVolumeMounts }}
@@ -146,6 +151,12 @@ spec:
         - name: public-key
           mountPath: /var/keys
           readOnly: true
+{{- end }}
+{{- if .Values.deployment.sidecarContainers }}
+{{- range $name, $spec :=  .Values.deployment.sidecarContainers }}
+      - name: {{ $name }}
+{{- toYaml $spec | nindent 8 }}
+{{- end }}
 {{- end }}
       {{- with .Values.resources }}
         resources:

--- a/releases/dist/releases/charts/chartmuseum/templates/ingress.yaml
+++ b/releases/dist/releases/charts/chartmuseum/templates/ingress.yaml
@@ -50,7 +50,7 @@ spec:
             {{- end }}
             port:
               number: {{ default $servicePort .port }}
-        pathType: ImplementationSpecific
+        pathType: {{ default $.Values.ingress.pathType .pathType }}
         {{- end }}
       {{- end }}
       - path: {{ default "/" .path | quote }}
@@ -71,7 +71,7 @@ spec:
             {{- end }}
             port:
               number: {{ default $servicePort .port }}
-        pathType: ImplementationSpecific
+        pathType: {{ $.Values.ingress.pathType }}
         {{- end }}
   {{- end }}
   tls:

--- a/releases/dist/releases/charts/chartmuseum/templates/pv.yaml
+++ b/releases/dist/releases/charts/chartmuseum/templates/pv.yaml
@@ -4,7 +4,7 @@ kind: PersistentVolume
 metadata:
   name: {{ .Values.persistence.pv.pvname | default (include "chartmuseum.fullname" .) }}
   labels:
-    {{- include "chartmuseum.selectorLabels" . | nindent 4 }}
+    {{- include "chartmuseum.labels" . | nindent 4 }}
 spec:
   capacity:
     storage: {{ .Values.persistence.pv.capacity.storage }}

--- a/releases/dist/releases/charts/chartmuseum/templates/pvc.yaml
+++ b/releases/dist/releases/charts/chartmuseum/templates/pvc.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ include "chartmuseum.fullname" . }}
   labels:
-    {{- include "chartmuseum.selectorLabels" . | nindent 4 }}
+    {{- include "chartmuseum.labels" . | nindent 4 }}
     {{- with .Values.persistence.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -20,7 +20,8 @@ spec:
 {{- else }}
   storageClassName: "{{ .Values.persistence.storageClass }}"
 {{- end }}
-{{- else if and .Values.persistence.volumeName (.Values.persistence.pv.enabled) }}
+{{- if .Values.persistence.volumeName }}
   volumeName: "{{ .Values.persistence.volumeName }}"
+{{- end }}
 {{- end }}
 {{- end }}

--- a/releases/dist/releases/charts/chartmuseum/templates/service.yaml
+++ b/releases/dist/releases/charts/chartmuseum/templates/service.yaml
@@ -34,10 +34,15 @@ spec:
   - port: {{ .Values.service.externalPort }}
 {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
     nodePort: {{.Values.service.nodePort}}
+{{- end }}
+{{- if .Values.service.targetPort }}
+    targetPort: {{ .Values.service.targetPort }}
+    name: {{ .Values.service.targetPort }}
 {{- else }}
     targetPort: http
+    name: http
 {{- end }}
     protocol: TCP
-    name: http
+    
   selector:
     {{- include "chartmuseum.selectorLabels" . | nindent 4 }}

--- a/releases/dist/releases/charts/chartmuseum/values.yaml
+++ b/releases/dist/releases/charts/chartmuseum/values.yaml
@@ -3,14 +3,16 @@ extraArgs: []
 replicaCount: 1
 strategy:
   type: RollingUpdate
-  rollingUpdate:
-    maxUnavailable: 0
 image:
   repository: ghcr.io/helm/chartmuseum
-  tag: v0.13.1
+  tag: v0.15.0
   pullPolicy: IfNotPresent
 secret:
   labels: {}
+## Labels to apply to all resources
+##
+commonLabels: {}
+# team_name: dev
 env:
   open:
     # storage backend, can be one of: local, alibaba, amazon, google, microsoft, oracle
@@ -68,8 +70,8 @@ env:
     LOG_JSON: true
     # disable use of index-cache.yaml
     DISABLE_STATEFILES: false
-    # disable Prometheus metrics
-    DISABLE_METRICS: true
+    # enable Prometheus metrics
+    ENABLE_METRICS: false
     # disable all routes prefixed with /api
     DISABLE_API: true
     # allow chart versions to be re-uploaded
@@ -131,8 +133,27 @@ deployment:
   #   name: value
   # additional volumes
   extraVolumes: []
+  #  - name: nginx-config
+  #    secret:
+  #      secretName: nginx-config
   # additional volumes to mount
   extraVolumeMounts: []
+  ## sidecarContainers for the Chartmuseum
+  # Can be used to add a proxy to the pod that does
+  # scanning for secrets, signing, authentication, validation
+  # of the chart's content, send notifications...
+  sidecarContainers: {}
+  ## Example sidecarContainer which uses an extraVolume from above and
+  ## a named port that can be referenced in the service as targetPort.
+  #  proxy:
+  #    image: nginx:latest
+  #    ports:
+  #      - name: proxy
+  #        containerPort: 8081
+  #    volumeMounts:
+  #      - name: nginx-config
+  #        readOnly: true
+  #        mountPath: /etc/nginx
 
 ## Pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
@@ -140,6 +161,11 @@ deployment:
 ##
 podAnnotations: {}
   # iam.amazonaws.com/role: role-arn
+
+## Pod labels
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+  # name: value
 
 service:
   servicename:
@@ -153,6 +179,10 @@ service:
   loadBalancerSourceRanges: []
   # clusterIP: None
   externalPort: 8080
+  ## targetPort of the container to use. If a sidecar should handle the
+  ## requests first, use the named port from the sidecar. See sidecar example
+  ## from deployment above. Leave empty to use chartmuseum directly.
+  targetPort:
   nodePort:
   annotations: {}
   labels: {}
@@ -180,12 +210,16 @@ probes:
     timeoutSeconds: 1
     successThreshold: 1
     failureThreshold: 3
+  livenessHttpGetConfig:
+    scheme: HTTP
   readiness:
     initialDelaySeconds: 5
     periodSeconds: 10
     timeoutSeconds: 1
     successThreshold: 1
     failureThreshold: 3
+  readinessHttpGetConfig:
+    scheme: HTTP
 
 serviceAccount:
   create: false
@@ -266,6 +300,7 @@ volumePermissions:
 ## Ingress for load balancer
 ingress:
   enabled: false
+  pathType: "ImplementationSpecific"
   ## Chartmuseum Ingress labels
   ##
   labels: {}

--- a/vendir-releases.yaml
+++ b/vendir-releases.yaml
@@ -129,7 +129,7 @@ directories:
       - path: chartmuseum
         helmChart:
           name: chartmuseum
-          version: 3.4.0
+          version: 3.9.3
           repository:
             url: https://chartmuseum.github.io/charts
 


### PR DESCRIPTION
- Bucket generation with release-cloud
- Service Account & credentials generation with release-cloud
- ServiceMonitor and default monitoring integration
- Overhaul of default configuration and exposed configuration option